### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please review our [Code of Conduct](https://github.com/moov-io/ach/blob/master/C
 
 We use GitHub to manage reviews of pull requests.
 
-* If you have a trivial fix or improvement, go ahead and create a pull request, addressing (with `@...`) one or more of the maintainers (see [AUTHORS.md](AUTHORS.md)) in the description of the pull request.
+* If you have a trivial fix or improvement, go ahead and create a pull request, addressing (with `@...`) one or more of the maintainers (see [AUTHORS](https://github.com/moov-io/ach-web-viewer/graphs/contributors)) in the description of the pull request.
 
 * If you plan to do something more involved, first propose your ideas in a Github issue. This will avoid unnecessary work and surely give you and us a good deal of inspiration.
 


### PR DESCRIPTION
Replace link to nonexistent AUTHORS.md page with link to GitHub Contributors page for the repo

# Why Are Changes Being Made

So ppl can find the "one or more of the maintainers" to "address (with @...)" if they "have a trivial fix or improvement" (like this one :-) when they "go ahead and create a pull request" by reading the CONTRIBUTING.md

cc: @wadearnold @adamdecaf 