### PR TITLE
fix: jail filesystem GetFile to configured roots

### DIFF
--- a/pkg/filelist/filesystem.go
+++ b/pkg/filelist/filesystem.go
@@ -79,6 +79,9 @@ func (ls *filesystemLister) GetFile(ctx context.Context, path string) (*File, er
 	if strings.Contains(path, "..") || strings.HasPrefix(path, "/") {
 		return nil, errors.New("invalid path")
 	}
+	if !ls.underConfiguredRoot(path) {
+		return nil, errors.New("invalid path")
+	}
 
 	fd, err := os.Open(path)
 	if err != nil {
@@ -100,4 +103,29 @@ func (ls *filesystemLister) GetFile(ctx context.Context, path string) (*File, er
 		CreatedAt:   stat.ModTime(),
 		Size:        stat.Size(),
 	}, parsed), err
+}
+
+// underConfiguredRoot reports whether path (after Clean) resolves inside
+// one of the configured filesystem roots. GetFiles only Walks those dirs;
+// GetFile used to os.Open any CWD-relative path that lacked ".." / "/".
+func (ls *filesystemLister) underConfiguredRoot(path string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	for _, root := range ls.dirs {
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(absRoot, absPath)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		return true
+	}
+	return false
 }

--- a/pkg/filelist/filesystem_test.go
+++ b/pkg/filelist/filesystem_test.go
@@ -1,0 +1,40 @@
+package filelist
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/ach-web-viewer/pkg/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilesystemGetFileJail(t *testing.T) {
+	ach, err := os.ReadFile(filepath.Join("..", "..", "testdata", "ppd-debit.ach"))
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	root := filepath.Join(dir, "ach")
+	require.NoError(t, os.Mkdir(root, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ppd-debit.ach"), ach, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("pwn"), 0600))
+
+	t.Chdir(dir)
+
+	ls, err := newFilesystemLister("src", &service.FilesystemConfig{Paths: []string{"ach"}})
+	require.NoError(t, err)
+
+	f, err := ls.GetFile(context.Background(), filepath.Join("ach", "ppd-debit.ach"))
+	require.NoError(t, err)
+	require.Equal(t, "ppd-debit.ach", f.Name)
+
+	_, err = ls.GetFile(context.Background(), "secret.txt")
+	require.EqualError(t, err, "invalid path")
+
+	_, err = ls.GetFile(context.Background(), "../secret.txt")
+	require.EqualError(t, err, "invalid path")
+
+	_, err = ls.GetFile(context.Background(), "/etc/passwd")
+	require.EqualError(t, err, "invalid path")
+}


### PR DESCRIPTION
# Changes

`GetFile` already rejected paths with `..` or a leading `/`, then called `os.Open` on whatever remained. `GetFiles` only `Walk`s the configured `Filesystem.Paths`. A CWD-relative path such as `secret.txt` or `go.mod` opened successfully.

This keeps the existing `..` / absolute checks and requires the resolved path to stay under one of those roots. Listed files under the configured dirs still open.

@adamdecaf

# Why Are Changes Being Made

Anyone who can GET the viewer already learns `sourceID` from `/`. They do not already have arbitrary filesystem read. The remaining guard is "reads stay under the configured roots." Listing encoded that. `GetFile` did not.

`TestFilesystemGetFileJail` fails if the root check is removed (`secret.txt` opens) and passes with it.