### PR TITLE
ci: push docker images only on official moov-io releases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,12 +47,3 @@ jobs:
     - name: Docker Build
       if: runner.os == 'Linux'
       run: make dev-docker
-
-    - name: Docker Push
-      if: runner.os == 'Linux'
-      run: |+
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make dev-push
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
 
   docker:
     name: Docker
+    if: github.repository_owner == 'moov-io' && !github.event.repository.fork
     needs: [testing, create_release]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Docker image **builds** still run on PRs. Docker **login/push** only happens from the release workflow, and only when `github.repository_owner == moov-io` and the repo is not a fork.

This stops PR CI (e.g. dependabot) from failing on empty `DOCKER_USERNAME` / `DOCKER_PASSWORD`, as in https://github.com/moov-io/rail-msg-sql/pull/72.